### PR TITLE
feat(tabs): add componentClass support

### DIFF
--- a/src/Tab.js
+++ b/src/Tab.js
@@ -25,6 +25,7 @@ class Tab extends React.Component {
     delete props.title;
     delete props.disabled;
     delete props.tabClassName;
+    delete props.tabComponentClass;
 
     return <TabPane {...props} />;
   }

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -69,7 +69,7 @@ function getDefaultActiveKey(children) {
 
 class Tabs extends React.Component {
   renderTab(child) {
-    const { title, eventKey, disabled, tabClassName } = child.props;
+    const { title, eventKey, disabled, tabClassName, tabComponentClass } = child.props;
     if (title == null) {
       return null;
     }
@@ -79,6 +79,7 @@ class Tabs extends React.Component {
         eventKey={eventKey}
         disabled={disabled}
         className={tabClassName}
+        componentClass={tabComponentClass}
       >
         {title}
       </NavItem>

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -259,6 +259,18 @@ describe('<Tabs>', () => {
     assert.equal(nav.context.$bs_tabContainer.activeKey, 2);
   });
 
+  it('Should render tab with the requested html button element', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Tabs id="test" defaultActiveKey={1}>
+        <Tab tabComponentClass="button" title="Tab 1" eventKey={1}>Tab 1 content</Tab>
+        <Tab tabComponentClass="button" title="Tab 2" eventKey={2}>Tab 2 content</Tab>
+      </Tabs>
+    );
+
+    const buttons = ReactTestUtils.scryRenderedDOMComponentsWithTag(instance, 'button');
+    assert.equal(buttons.length, 2);
+  });
+
 
   describe('active state invariants', () => {
     let mountPoint;


### PR DESCRIPTION
This contribution is a non breaking change.
The scope of this contribution is to help user define with wich html tag the use want to have the tab list elements rendered.

Exemple: rendering tabs as `button` instead of `a` 